### PR TITLE
Remove TLSv1 restriction

### DIFF
--- a/pyweechat/socket.py
+++ b/pyweechat/socket.py
@@ -19,7 +19,7 @@ class WeeChatSocket:
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if use_ssl:
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.verify_mode = ssl.CERT_REQUIRED
             context.check_hostname = True
             if custom_cert:


### PR DESCRIPTION
Using ssl.PROTOCOL_TLSv1 will fail when the Webserver does not support TLSv1 anymore. Also, specifying a TLS version is deprecated according to the documentation of the SSL module: https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1

This patch exchanges it for the proposed ssl.PROTOCOL_TLS.